### PR TITLE
Fix: Adjust margin for project cards on mobile

### DIFF
--- a/src/components/Works.jsx
+++ b/src/components/Works.jsx
@@ -108,7 +108,7 @@ const Works = () => {
         </motion.p>
       </div>
 
-      <div className='mt-20 flex flex-wrap gap-7'>
+      <div className='mt-10 sm:mt-16 flex flex-wrap gap-7'>
         {projects.map((project, index) => (
           <ProjectCard
             key={`project-${index}`}


### PR DESCRIPTION
Reduces the top margin of the project cards container in the "My Work" section on smaller screens.

Changed `mt-20` to `mt-10 sm:mt-16` in `src/components/Works.jsx`. This addresses an issue where excessive margin could make it appear as if there was empty space above the project cards on mobile devices until significant scrolling.